### PR TITLE
add AlertService

### DIFF
--- a/alert.go
+++ b/alert.go
@@ -1,0 +1,81 @@
+package aapi
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// AlertService handles requests to the on-call alerts endpoint.
+//
+// // https://grafana.com/docs/oncall/latest/oncall-api-reference/alerts/
+type AlertService struct {
+	client *Client
+	url    string
+}
+
+// NewAlertService creates an AlertService with the defined URL.
+func NewAlertService(client *Client) *AlertService {
+	alertService := AlertService{}
+	alertService.client = client
+	alertService.url = "alerts"
+	return &alertService
+}
+
+// PaginatedAlertsResponse represents a paginated response from the on-call alerts API.
+type PaginatedAlertsResponse struct {
+	PaginatedResponse
+	Alerts []*Alert `json:"results"`
+}
+
+// Alert represents an on-call alert.
+type Alert struct {
+	ID           string       `json:"id"`
+	AlertGroupID string       `json:"alert_group_id"`
+	CreatedAt    string       `json:"created_at"`
+	Payload      AlertPayload `json:"payload"`
+}
+
+// AlertPayload represents an on-call alert payload.
+type AlertPayload struct {
+	State       string           `json:"state"`
+	Title       string           `json:"title"`
+	RuleID      int              `json:"ruleId"`
+	Message     string           `json:"message"`
+	RuleURL     string           `json:"ruleUrl"`
+	RuleName    string           `json:"ruleName"`
+	EvalMatches []AlertEvalMatch `json:"evalMatches"`
+}
+
+// AlertEvalMatch represents an on-call alert payload evalMatch.
+type AlertEvalMatch struct {
+	Tags   []string `json:"tags"`
+	Value  int64    `json:"value"`
+	Metric string   `json:"metric"`
+}
+
+// ListAlertOptions represent filter options supported by the on-call alerts API.
+type ListAlertOptions struct {
+	ListOptions
+	AlertGroupID string `url:"alert_group_id,omitempty" json:"alert_group_id,omitempty"`
+	Name         string `url:"search,omitempty" json:"search,omitempty"`
+}
+
+// ListAlerts fetches all on-call alerts for authorized organization.
+//
+// https://grafana.com/docs/oncall/latest/oncall-api-reference/alerts/
+func (service *AlertService) ListAlerts(opt *ListAlertOptions) (*PaginatedAlertsResponse, *http.Response, error) {
+	u := fmt.Sprintf("%s/", service.url)
+
+	req, err := service.client.NewRequest("GET", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var alerts *PaginatedAlertsResponse
+	resp, err := service.client.Do(req, &alerts)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return alerts, resp, err
+}

--- a/alert_test.go
+++ b/alert_test.go
@@ -1,0 +1,98 @@
+package aapi
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var evalMatches = []AlertEvalMatch{
+	{
+		Value:  100,
+		Metric: "High value",
+	},
+	{
+		Value:  200,
+		Metric: "Higher value",
+	},
+}
+
+var payload = AlertPayload{
+	State:       "alerting",
+	Title:       "[Alerting] Test notification",
+	RuleID:      0,
+	Message:     "Someone is testing the alert notification within Grafana.",
+	RuleURL:     "{{API_URL}}/",
+	RuleName:    "Test notification",
+	EvalMatches: evalMatches,
+}
+
+var testAlert = &Alert{
+	ID:           "OH3V5FYQEYJ6M",
+	AlertGroupID: "T3HRAP3K3IKOP",
+	CreatedAt:    "2020-05-11T20:07:43Z",
+	Payload:      payload,
+}
+
+var testAlertBody = `{
+	"id": "OH3V5FYQEYJ6M",
+	"alert_group_id": "T3HRAP3K3IKOP",
+	"created_at": "2020-05-11T20:07:43Z",
+	"payload": {
+		"state": "alerting",
+		"title": "[Alerting] Test notification",
+		"ruleId": 0,
+		"message": "Someone is testing the alert notification within Grafana.",
+		"ruleUrl": "{{API_URL}}/",
+		"ruleName": "Test notification",
+		"evalMatches": [
+			{
+				"tags": null,
+				"value": 100,
+				"metric": "High value"
+			},
+			{
+				"tags": null,
+				"value": 200,
+				"metric": "Higher value"
+			}
+		]
+	}
+}`
+
+func TestListAlerts(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v1/alerts/", func(w http.ResponseWriter, r *http.Request) {
+		testRequestMethod(t, r, "GET")
+		fmt.Fprint(w, fmt.Sprintf(`{"count": 1, "next": null, "previous": null, "results": [%s]}`, testAlertBody))
+	})
+
+	options := &ListAlertOptions{
+		AlertGroupID: "SBM7DV7BKFUYU",
+	}
+
+	alerts, _, err := client.Alerts.ListAlerts(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &PaginatedAlertsResponse{
+		PaginatedResponse: PaginatedResponse{
+			Count:    1,
+			Next:     nil,
+			Previous: nil,
+		},
+		Alerts: []*Alert{
+			testAlert,
+		},
+	}
+
+	if !reflect.DeepEqual(want, alerts) {
+		fmt.Println(alerts.Alerts[0])
+		fmt.Println(want.Alerts[0])
+		t.Errorf(" returned\n %+v, \nwant\n %+v", alerts, want)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -42,6 +42,7 @@ type Client struct {
 	disableRetries bool
 	limiter        *rate.Limiter
 	// List of Services. Keep in sync with func newClient
+	Alerts           *AlertService
 	Integrations     *IntegrationService
 	EscalationChains *EscalationChainService
 	Escalations      *EscalationService
@@ -94,6 +95,7 @@ func newClient(url string) (*Client, error) {
 	}
 
 	// Create services. Keep in sync with Client struct
+	c.Alerts = NewAlertService(c)
 	c.Integrations = NewIntegrationService(c)
 	c.EscalationChains = NewEscalationChainService(c)
 	c.Escalations = NewEscalationService(c)


### PR DESCRIPTION
This seeks to add a `AlertService` client for interacting with
the Grafana OnCall [alerts HTTP API](https://grafana.com/docs/grafana-cloud/oncall/oncall-api-reference/alerts/).

Currently, the `AlertService` has a single `ListAlerts` method used
to interact with the only documented OnCall alerts endpoint.