### PR TITLE
Add routing_type param for regex or jinja2 route match

### DIFF
--- a/route.go
+++ b/route.go
@@ -33,6 +33,7 @@ type Route struct {
 	EscalationChainId string         `json:"escalation_chain_id"`
 	Position          int            `json:"position"`
 	RoutingRegex      string         `json:"routing_regex"`
+	RoutingType       string         `json:"routing_type"`
 	IsTheLastRoute    bool           `json:"is_the_last_route"`
 	SlackRoute        *SlackRoute    `json:"slack"`
 	TelegramRoute     *TelegramRoute `json:"telegram"`
@@ -45,17 +46,18 @@ type SlackRoute struct {
 }
 type TelegramRoute struct {
 	Id      *string `json:"id"`
-    Enabled bool    `json:"enabled"`
+	Enabled bool    `json:"enabled"`
 }
 type MSTeamsRoute struct {
 	Id      *string `json:"id"`
-    Enabled bool    `json:"enabled"`
+	Enabled bool    `json:"enabled"`
 }
 
 type ListRouteOptions struct {
 	ListOptions
 	IntegrationId string `url:"integration_id,omitempty" json:"integration_id,omitempty"`
 	RoutingRegex  string `url:"routing_regex,omitempty" json:"routing_regex,omitempty"`
+	RoutingType   string `url:"routing_type,omitempty" json:"routing_type,omitempty"`
 }
 
 // ListRoutes fetches all routes for authorized organization
@@ -106,6 +108,7 @@ type CreateRouteOptions struct {
 	EscalationChainId string         `json:"escalation_chain_id,omitempty"`
 	Position          *int           `json:"position,omitempty"`
 	RoutingRegex      string         `json:"routing_regex,omitempty"`
+	RoutingType       string         `json:"routing_type,omitempty"`
 	Slack             *SlackRoute    `json:"slack,omitempty"`
 	Telegram          *TelegramRoute `json:"telegram,omitempty"`
 	MSTeams           *MSTeamsRoute  `json:"msteams,omitempty"`
@@ -141,6 +144,7 @@ type UpdateRouteOptions struct {
 	Telegram          *TelegramRoute `json:"telegram,omitempty"`
 	MSTeams           *MSTeamsRoute  `json:"msteams,omitempty"`
 	RoutingRegex      string         `json:"routing_regex,omitempty"`
+	RoutingType       string         `json:"routing_type,omitempty"`
 	ManualOrder       bool           `url:"manual_order,omitempty" json:"manual_order,omitempty"`
 }
 

--- a/route_test.go
+++ b/route_test.go
@@ -16,18 +16,19 @@ var testRoute = &Route{
 	IntegrationId:  "CGEXJ922S7TXQ",
 	Position:       0,
 	RoutingRegex:   "us-west",
+	RoutingType:    "regex",
 	IsTheLastRoute: false,
 	SlackRoute: &SlackRoute{
 		ChannelId: &testSlackChannelId,
-		Enabled: true,
+		Enabled:   true,
 	},
 	TelegramRoute: &TelegramRoute{
-	    Id: &testTelegramChannelId,
-	    Enabled: true,
+		Id:      &testTelegramChannelId,
+		Enabled: true,
 	},
 	MSTeamsRoute: &MSTeamsRoute{
-	    Id: &testMSTeamsChannelId,
-	    Enabled: true,
+		Id:      &testMSTeamsChannelId,
+		Enabled: true,
 	},
 }
 
@@ -35,6 +36,7 @@ var testRouteBody = `{
 	"id": "RH2V5FYIPYJ1M",
 	"integration_id": "CGEXJ922S7TXQ",
 	"routing_regex": "us-west",
+	"routing_type": "regex",
 	"position": 0,
 	"is_the_last_route": false,
 	"slack": {
@@ -63,17 +65,18 @@ func TestCreateRoute(t *testing.T) {
 	createOptions := &CreateRouteOptions{
 		IntegrationId: "CGEXJ922S7TXQ",
 		RoutingRegex:  "us-west",
+		RoutingType:   "regex",
 		Slack: &SlackRoute{
 			ChannelId: &testSlackChannelId,
-			Enabled: true,
+			Enabled:   true,
 		},
 		Telegram: &TelegramRoute{
-		    Id: &testTelegramChannelId,
-		    Enabled: true,
+			Id:      &testTelegramChannelId,
+			Enabled: true,
 		},
 		MSTeams: &MSTeamsRoute{
-		    Id: &testMSTeamsChannelId,
-		    Enabled: true,
+			Id:      &testMSTeamsChannelId,
+			Enabled: true,
 		},
 	}
 	route, _, err := client.Routes.CreateRoute(createOptions)


### PR DESCRIPTION
PR adds the `routing_type` for OnCall integration routing. `routing_type` can be `regex` or `jinja2`. 

https://grafana.com/docs/oncall/latest/oncall-api-reference/routes/#create-a-route