### PR TITLE
Expose RetryClient externally

### DIFF
--- a/client.go
+++ b/client.go
@@ -37,7 +37,7 @@ type PaginatedResponse struct {
 
 type Client struct {
 	// HTTP client used to communicate with the API.
-	client         *retryablehttp.Client
+	Client         *retryablehttp.Client
 	token          string
 	baseURL        *url.URL
 	disableRetries bool
@@ -79,7 +79,7 @@ func newClient(url string) (*Client, error) {
 	c := &Client{}
 
 	// Configure the HTTP client.
-	c.client = &retryablehttp.Client{
+	c.Client = &retryablehttp.Client{
 		Backoff:      c.retryHTTPBackoff,
 		CheckRetry:   c.retryHTTPCheck,
 		RetryWaitMin: 100 * time.Millisecond,
@@ -190,7 +190,7 @@ func (c *Client) Do(req *retryablehttp.Request, v interface{}) (*http.Response, 
 		return nil, err
 	}
 
-	resp, err := c.client.Do(req)
+	resp, err := c.Client.Do(req)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Greetings,

This is a bit far-reaching PR. We're using https://github.com/grafana/terraform-provider-grafana which uses this library for Grafana OnCall API. 
1. `terraform-provider-grafana` has an [option](https://registry.terraform.io/providers/grafana/grafana/latest/docs#insecure_skip_verify) called `insecure_skip_verify` which allows to use the provider when hosting Grafana on self-signed (/self-hosted) certificates. 
2. Unfortunately, I've recently discovered that the [`insecure_skip_verify`](https://github.com/grafana/terraform-provider-grafana/blob/8020b139bf85d83ddb17106b8da2b13ea0847502/pkg/provider/configure_clients.go#L247) option that is defined, used in [`parseTLSConfig`](https://github.com/grafana/terraform-provider-grafana/blob/8020b139bf85d83ddb17106b8da2b13ea0847502/pkg/provider/configure_clients.go#L222C6-L222C20) method which is [used only once ](https://github.com/grafana/terraform-provider-grafana/blob/8020b139bf85d83ddb17106b8da2b13ea0847502/pkg/provider/configure_clients.go#L66-L67) for configuring main Grafana API client, which in turns mean that we cannot use the provider to connect to Grafana OnCall API with self-signed certificates.

As `terraform-provider-grafana` uses this library, the easy way to change that is to expose `RetryableHTTP` client field publicly, so users of this library (`terraform-provider-grafana`) can use the same `parseTLSConfig` and pass the appropriate TLS settings to underlying Go HTTP Client.