### PR TITLE
Add option to instantiate client passing grafana URL

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -47,6 +47,55 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientWithGrafanaURL(t *testing.T) {
+	c, err := NewWithGrafanaURL("base_url", "token", "grafana_url")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	expectedBaseURL := "base_url/" + apiVersionPath
+
+	if c.BaseURL().String() != expectedBaseURL {
+		t.Errorf("NewClient BaseURL is %s, want %s", c.BaseURL().String(), expectedBaseURL)
+	}
+
+	if c.GrafanaURL().String() != "grafana_url" {
+		t.Errorf("NewClient GrafanaURL is %s, want grafana_url", c.GrafanaURL().String())
+	}
+}
+
+func TestCheckRequest(t *testing.T) {
+	c, err := New("base_url", "token")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	req, err := c.NewRequest("GET", "test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	if req.Header.Get("X-Grafana-URL") != "" {
+		t.Errorf("X-Grafana-URL should not be set: %s", req.Header.Get("X-Grafana-URL"))
+	}
+}
+
+func TestCheckRequestSettingGrafanaURL(t *testing.T) {
+	c, err := NewWithGrafanaURL("base_url", "token", "grafana_url")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	req, err := c.NewRequest("GET", "test", nil)
+	if err != nil {
+		t.Fatalf("Failed to create request: %v", err)
+	}
+
+	if req.Header.Get("X-Grafana-URL") != "grafana_url" {
+		t.Errorf("X-Grafana-URL is not set correctly: %s", req.Header.Get("X-Grafana-URL"))
+	}
+}
+
 func TestCheckResponse(t *testing.T) {
 	c, err := New("base_url", "token")
 	if err != nil {

--- a/integration_test.go
+++ b/integration_test.go
@@ -110,7 +110,7 @@ var testIntegrationBody = `{
 	   "mobile_app":{
 		  "title":null,
 		  "message":null
-	   },
+	   }
 	}
  }`
 

--- a/on_call_shift_test.go
+++ b/on_call_shift_test.go
@@ -13,13 +13,15 @@ var byDay = []string{"MO", "FR"}
 var interval = 2
 var users = []string{"U4DNY931HHJS5", "U6RV9WPSL6DFW"}
 
+var until = "2020-09-05T13:00:00"
+
 var testOnCallShift = &OnCallShift{
 	ID:        "OH3V5FYQEYJ6M",
 	TeamId:    "T3HRAP3K3IKOP",
 	Name:      "Test On-Call Shift",
 	Type:      "recurrent_event",
 	Start:     "2020-09-04T13:00:00",
-	Until:     "2020-09-05T13:00:00",
+	Until:     &until,
 	Level:     0,
 	Duration:  7200,
 	Frequency: &frequency,


### PR DESCRIPTION
Related to https://github.com/grafana/oncall-private/issues/2826

Requires https://github.com/grafana/oncall/pull/5254

Required for https://github.com/grafana/terraform-provider-grafana/pull/1859

Grafana URL is used to identify the OnCall organization and validate the service account token (if one is provided for auth)
(also fixed a couple of previously failing tests)