### PR TITLE
Allow instantiating the client with an empty string token

### DIFF
--- a/client.go
+++ b/client.go
@@ -61,10 +61,6 @@ type Client struct {
 }
 
 func NewWithGrafanaURL(base_url, token, grafana_url string) (*Client, error) {
-	if token == "" {
-		return nil, fmt.Errorf("Token required")
-	}
-
 	if base_url == "" {
 		return nil, fmt.Errorf("BaseUrl required")
 	}
@@ -77,10 +73,6 @@ func NewWithGrafanaURL(base_url, token, grafana_url string) (*Client, error) {
 }
 
 func New(base_url, token string) (*Client, error) {
-	if token == "" {
-		return nil, fmt.Errorf("Token required")
-	}
-
 	if base_url == "" {
 		return nil, fmt.Errorf("BaseUrl required")
 	}

--- a/client_test.go
+++ b/client_test.go
@@ -47,8 +47,38 @@ func TestNewClient(t *testing.T) {
 	}
 }
 
+func TestNewClientEmptyToken(t *testing.T) {
+	c, err := New("base_url", "")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	expectedBaseURL := "base_url/" + apiVersionPath
+
+	if c.BaseURL().String() != expectedBaseURL {
+		t.Errorf("NewClient BaseURL is %s, want %s", c.BaseURL().String(), expectedBaseURL)
+	}
+}
+
 func TestNewClientWithGrafanaURL(t *testing.T) {
 	c, err := NewWithGrafanaURL("base_url", "token", "grafana_url")
+	if err != nil {
+		t.Fatalf("Failed to create client: %v", err)
+	}
+
+	expectedBaseURL := "base_url/" + apiVersionPath
+
+	if c.BaseURL().String() != expectedBaseURL {
+		t.Errorf("NewClient BaseURL is %s, want %s", c.BaseURL().String(), expectedBaseURL)
+	}
+
+	if c.GrafanaURL().String() != "grafana_url" {
+		t.Errorf("NewClient GrafanaURL is %s, want grafana_url", c.GrafanaURL().String())
+	}
+}
+
+func TestNewClientWithGrafanaURLEmptyToken(t *testing.T) {
+	c, err := NewWithGrafanaURL("base_url", "", "grafana_url")
 	if err != nil {
 		t.Fatalf("Failed to create client: %v", err)
 	}


### PR DESCRIPTION
Related to https://github.com/grafana/terraform-provider-grafana/issues/1953

Allow empty token strings when instantiating the client (eg. when using the client via terraform, the token may be not initially known).