### PR TITLE
Add alertGroup Service to implement alert_groups API endpoints

### DIFF
--- a/alert_group.go
+++ b/alert_group.go
@@ -1,0 +1,72 @@
+package aapi
+
+import (
+	"fmt"
+	"net/http"
+)
+
+// AlertGroupService handles requests to the on-call alert_groups endpoint.
+//
+// https://grafana.com/docs/oncall/latest/oncall-api-reference/alertgroups/
+type AlertGroupService struct {
+	client *Client
+	url    string
+}
+
+// NewAlertGroupService creates an AlertGroupService with the defined URL.
+func NewAlertGroupService(client *Client) *AlertGroupService {
+	alertGroupService := AlertGroupService{}
+	alertGroupService.client = client
+	alertGroupService.url = "alert_groups"
+	return &alertGroupService
+}
+
+// PaginatedAlertGroupsResponse represents a paginated response from the on-call alerts API.
+type PaginatedAlertGroupsResponse struct {
+	PaginatedResponse
+	AlertGroups []*AlertGroup `json:"results"`
+}
+
+// AlertGroup represents an on-call alert group.
+type AlertGroup struct {
+	ID             string            `json:"id"`
+	IntegrationID  string            `json:"integration_id"`
+	RouteID        string            `json:"route_id"`
+	AlertsCount    int               `json:"alerts_count"`
+	State          string            `json:"state"`
+	CreatedAt      string            `json:"created_at"`
+	ResolvedAt     string            `json:"resolved_at"`
+	AcknowledgedAt string            `json:"acknowledged_at"`
+	Title          string            `json:"title"`
+	Permalinks     map[string]string `json:"permalinks"`
+}
+
+// ListAlertGroupOptions represent filter options supported by the on-call alert_groups API.
+type ListAlertGroupOptions struct {
+	ListOptions
+	AlertGroupID  string `url:"alert_group_id,omitempty" json:"alert_group_id,omitempty"`
+	RouteID       string `url:"route_id,omitempty" json:"route_id,omitempty"`
+	IntegrationID string `url:"integration_id,omitempty" json:"integration_id,omitempty" `
+	State         string `url:"state,omitempty" json:"state,omitempty" `
+	Name          string `url:"name,omitempty" json:"name,omitempty"`
+}
+
+// ListAlertGroups fetches all on-call alerts for authorized organization.
+//
+// https://grafana.com/docs/oncall/latest/oncall-api-reference/alertgroups/
+func (service *AlertGroupService) ListAlertGroups(opt *ListAlertGroupOptions) (*PaginatedAlertGroupsResponse, *http.Response, error) {
+	u := fmt.Sprintf("%s/", service.url)
+
+	req, err := service.client.NewRequest("GET", u, opt)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var alertGroups *PaginatedAlertGroupsResponse
+	resp, err := service.client.Do(req, &alertGroups)
+	if err != nil {
+		return nil, resp, err
+	}
+
+	return alertGroups, resp, err
+}

--- a/alert_group_test.go
+++ b/alert_group_test.go
@@ -1,0 +1,75 @@
+package aapi
+
+import (
+	"fmt"
+	"net/http"
+	"reflect"
+	"testing"
+)
+
+var testAlertGroup = &AlertGroup{
+	ID:            "I68T24C13IFW1",
+	IntegrationID: "CFRPV98RPR1U8",
+	RouteID:       "RIYGUJXCPFHXY",
+	AlertsCount:   3,
+	State:         "resolved",
+	CreatedAt:     "2020-05-19T12:37:01.430444Z",
+	ResolvedAt:    "2020-05-19T13:37:01.429805Z",
+	Title:         "Memory above 90% threshold",
+	Permalinks: map[string]string{
+		"slack":    "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008",
+		"telegram": "https://t.me/c/5354/1234?thread=1234",
+	},
+}
+
+var testAlertGroupBody = `{
+	"id": "I68T24C13IFW1",
+	"integration_id": "CFRPV98RPR1U8",
+	"route_id": "RIYGUJXCPFHXY",
+	"alerts_count": 3,
+	"state": "resolved",
+	"created_at": "2020-05-19T12:37:01.430444Z",
+	"resolved_at": "2020-05-19T13:37:01.429805Z",
+	"acknowledged_at": null,
+	"title": "Memory above 90% threshold",
+	"permalinks": {
+	  "slack": "https://ghostbusters.slack.com/archives/C1H9RESGA/p135854651500008",
+	  "telegram": "https://t.me/c/5354/1234?thread=1234"
+	}
+}`
+
+func TestListAlertGroup(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v1/alert_groups/", func(w http.ResponseWriter, r *http.Request) {
+		testRequestMethod(t, r, "GET")
+		fmt.Fprint(w, fmt.Sprintf(`{"count": 1, "next": null, "previous": null, "results": [%s]}`, testAlertGroupBody))
+	})
+
+	options := &ListAlertGroupOptions{
+		AlertGroupID: "I68T24C13IFW1",
+	}
+
+	alerts, _, err := client.AlertGroups.ListAlertGroups(options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	want := &PaginatedAlertGroupsResponse{
+		PaginatedResponse: PaginatedResponse{
+			Count:    1,
+			Next:     nil,
+			Previous: nil,
+		},
+		AlertGroups: []*AlertGroup{
+			testAlertGroup,
+		},
+	}
+
+	if !reflect.DeepEqual(want, alerts) {
+		fmt.Println(alerts.AlertGroups[0])
+		fmt.Println(want.AlertGroups[0])
+		t.Errorf(" returned\n %+v, \nwant\n %+v", alerts, want)
+	}
+}

--- a/client.go
+++ b/client.go
@@ -38,6 +38,7 @@ type Client struct {
 	UserAgent  string
 	// List of Services. Keep in sync with func newClient
 	Alerts                *AlertService
+	AlertGroups           *AlertGroupService
 	Integrations          *IntegrationService
 	EscalationChains      *EscalationChainService
 	Escalations           *EscalationService
@@ -97,6 +98,7 @@ func newClient(url, grafana_url string) (*Client, error) {
 
 	// Create services. Keep in sync with Client struct
 	c.Alerts = NewAlertService(c)
+	c.AlertGroups = NewAlertGroupService(c)
 	c.Integrations = NewIntegrationService(c)
 	c.EscalationChains = NewEscalationChainService(c)
 	c.Escalations = NewEscalationService(c)


### PR DESCRIPTION
This PR is based on the work originally submitted by @ese in PR #[15](https://github.com/grafana/amixr-api-go-client/pull/15).

## Credit
Original work by @ese

This PR only resolved conflicts to help move this contribution forward and replaces PR #[15](https://github.com/grafana/amixr-api-go-client/pull/15).