### PR TITLE
Add teamID to the schedule list options

### DIFF
--- a/schedule.go
+++ b/schedule.go
@@ -47,10 +47,13 @@ type SlackSchedule struct {
 
 type ListScheduleOptions struct {
 	ListOptions
-	Name string `url:"name,omitempty" json:"name,omitempty"`
+	Name   string `url:"name,omitempty" json:"name,omitempty"`
+	TeamID string `url:"team_id,omitempty" json:"team_id,omitempty"`
 }
 
 // ListSchedules fetches all schedules for authorized organization
+// Optional filter:
+// - team_id: Exact match filter for team ID
 //
 // https://grafana.com/docs/grafana-cloud/oncall/oncall-api-reference/schedules/#list-schedules
 func (service *ScheduleService) ListSchedules(opt *ListScheduleOptions) (*PaginatedSchedulesResponse, *http.Response, error) {


### PR DESCRIPTION
Adds `team_id` parameter to list schedules functionality which is supported according to the [docs](https://grafana.com/docs/grafana-cloud/alerting-and-irm/irm/reference/oncall-api/schedules/).