### PR TITLE
alert_groups: add additional options as query parameters

### DIFF
--- a/alert_group.go
+++ b/alert_group.go
@@ -3,6 +3,8 @@ package aapi
 import (
 	"fmt"
 	"net/http"
+	"regexp"
+	"time"
 )
 
 // AlertGroupService handles requests to the on-call alert_groups endpoint.
@@ -41,6 +43,48 @@ type AlertGroup struct {
 	Permalinks     map[string]string `json:"permalinks"`
 }
 
+// validateTimeRange validates if the time range string matches the expected format
+// Expected format: %Y-%m-%dT%H:%M:%S_%Y-%m-%dT%H:%M:%S
+func validateTimeRange(timeRange string) error {
+	if timeRange == "" {
+		return nil
+	}
+
+	// Check if the string matches the expected format
+	pattern := `^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}_\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}$`
+	matched, err := regexp.MatchString(pattern, timeRange)
+	if err != nil {
+		return fmt.Errorf("error validating time range format: %v", err)
+	}
+	if !matched {
+		return fmt.Errorf("invalid time range format. Expected format: YYYY-MM-DDThh:mm:ss_YYYY-MM-DDThh:mm:ss")
+	}
+
+	// Split the time range into start and end times
+	times := regexp.MustCompile(`_`).Split(timeRange, 2)
+	if len(times) != 2 {
+		return fmt.Errorf("invalid time range format: missing separator '_'")
+	}
+
+	// Parse both times to ensure they are valid
+	startTime, err := time.Parse("2006-01-02T15:04:05", times[0])
+	if err != nil {
+		return fmt.Errorf("invalid start time format: %v", err)
+	}
+
+	endTime, err := time.Parse("2006-01-02T15:04:05", times[1])
+	if err != nil {
+		return fmt.Errorf("invalid end time format: %v", err)
+	}
+
+	// Validate that end time is after start time
+	if endTime.Before(startTime) {
+		return fmt.Errorf("end time must be after start time")
+	}
+
+	return nil
+}
+
 // ListAlertGroupOptions represent filter options supported by the on-call alert_groups API.
 type ListAlertGroupOptions struct {
 	ListOptions
@@ -48,13 +92,36 @@ type ListAlertGroupOptions struct {
 	RouteID       string `url:"route_id,omitempty" json:"route_id,omitempty"`
 	IntegrationID string `url:"integration_id,omitempty" json:"integration_id,omitempty" `
 	State         string `url:"state,omitempty" json:"state,omitempty" `
-	Name          string `url:"name,omitempty" json:"name,omitempty"`
+	TeamID        string `url:"team_id,omitempty" json:"team_id,omitempty"`
+	// StartedAt is a time range in ISO 8601 format with start and end timestamps separated by underscore.
+	// Expected format: %Y-%m-%dT%H:%M:%S_%Y-%m-%dT%H:%M:%S
+	// Example: "2024-03-20T10:00:00_2024-03-21T10:00:00"
+	StartedAt string `url:"started_at,omitempty" json:"started_at,omitempty"`
+	// Labels are matching labels that can be passed multiple times.
+	// Expected format: key1:value1
+	// Example: ["env:prod", "severity:high"]
+	Labels []string `url:"label,omitempty" json:"label,omitempty"`
+	Name   string   `url:"name,omitempty" json:"name,omitempty"`
+}
+
+// Validate checks if the options are valid
+func (o *ListAlertGroupOptions) Validate() error {
+	if err := validateTimeRange(o.StartedAt); err != nil {
+		return err
+	}
+	return nil
 }
 
 // ListAlertGroups fetches all on-call alerts for authorized organization.
 //
 // https://grafana.com/docs/oncall/latest/oncall-api-reference/alertgroups/
 func (service *AlertGroupService) ListAlertGroups(opt *ListAlertGroupOptions) (*PaginatedAlertGroupsResponse, *http.Response, error) {
+	if opt != nil {
+		if err := opt.Validate(); err != nil {
+			return nil, nil, err
+		}
+	}
+
 	u := fmt.Sprintf("%s/", service.url)
 
 	req, err := service.client.NewRequest("GET", u, opt)

--- a/alert_group_test.go
+++ b/alert_group_test.go
@@ -73,3 +73,138 @@ func TestListAlertGroup(t *testing.T) {
 		t.Errorf(" returned\n %+v, \nwant\n %+v", alerts, want)
 	}
 }
+
+func TestValidateTimeRange(t *testing.T) {
+	tests := []struct {
+		name      string
+		timeRange string
+		wantErr   bool
+	}{
+		{
+			name:      "valid time range",
+			timeRange: "2024-03-20T10:00:00_2024-03-21T10:00:00",
+			wantErr:   false,
+		},
+		{
+			name:      "empty time range",
+			timeRange: "",
+			wantErr:   false,
+		},
+		{
+			name:      "invalid format - missing separator",
+			timeRange: "2024-03-20T10:00:002024-03-21T10:00:00",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid format - wrong date format",
+			timeRange: "2024/03/20T10:00:00_2024/03/21T10:00:00",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid time - end before start",
+			timeRange: "2024-03-21T10:00:00_2024-03-20T10:00:00",
+			wantErr:   true,
+		},
+		{
+			name:      "invalid time - invalid hour",
+			timeRange: "2024-03-20T25:00:00_2024-03-21T10:00:00",
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateTimeRange(tt.timeRange)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("validateTimeRange() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestListAlertGroupsValidation(t *testing.T) {
+	tests := []struct {
+		name    string
+		options *ListAlertGroupOptions
+		wantErr bool
+	}{
+		{
+			name: "valid options",
+			options: &ListAlertGroupOptions{
+				StartedAt: "2024-03-20T10:00:00_2024-03-21T10:00:00",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid time range",
+			options: &ListAlertGroupOptions{
+				StartedAt: "invalid-time-range",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.options.Validate()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListAlertGroupOptions.Validate() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestListAlertGroupQueryURL(t *testing.T) {
+	tests := []struct {
+		name        string
+		options     *ListAlertGroupOptions
+		expectedURL string
+	}{
+		{
+			name: "single label",
+			options: &ListAlertGroupOptions{
+				Labels: []string{"env:prod"},
+			},
+			expectedURL: "/api/v1/alert_groups/?label=env%3Aprod",
+		},
+		{
+			name: "multiple labels",
+			options: &ListAlertGroupOptions{
+				Labels: []string{"env:prod", "severity:high", "team:backend"},
+			},
+			expectedURL: "/api/v1/alert_groups/?label=env%3Aprod&label=severity%3Ahigh&label=team%3Abackend",
+		},
+		{
+			name: "empty labels",
+			options: &ListAlertGroupOptions{
+				Labels: []string{},
+			},
+			expectedURL: "/api/v1/alert_groups/",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mux, server, client := setup(t)
+			defer teardown(server)
+
+			var capturedURL string
+			mux.HandleFunc("/api/v1/alert_groups/", func(w http.ResponseWriter, r *http.Request) {
+				capturedURL = r.URL.String()
+				t.Logf("Request URL: %s", capturedURL)
+				w.WriteHeader(http.StatusOK)
+				// Add minimal response body
+				fmt.Fprint(w, `{"count": 0, "next": null, "previous": null, "results": []}`)
+			})
+
+			_, _, err := client.AlertGroups.ListAlertGroups(tt.options)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if capturedURL != tt.expectedURL {
+				t.Errorf("Request URL = %v, want %v", capturedURL, tt.expectedURL)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR adds support for filtering alert groups by labels, teamID and startedAt as described [here](https://grafana.com/docs/oncall/latest/oncall-api-reference/alertgroups/) and includes validation tests:

Code Changes - Added Fields to ListAlertGroupOptions struct:
- Labels field to support multiple label filters
- TeamID
- StartedAt to support specific time range

Testing:
- Added focused URL validation test to verify correct URL construction when added Label option
- Test cases cover single label, multiple labels, and empty labels scenarios
- Tests for StartedAt option validation 