### PR TITLE
feat: Oncall integration labels

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,4 @@ go 1.16
 require (
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/go-retryablehttp v0.7.7
-	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 )

--- a/go.sum
+++ b/go.sum
@@ -33,7 +33,5 @@ golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.14.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/sys v0.20.0 h1:Od9JTbYCk261bKm4M/mw7AklTlFYIa0bIp9BgSm1S8Y=
 golang.org/x/sys v0.20.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
-golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e h1:EHBhcS0mlXEAVwNyO2dLfjToGsyY4j24pTs2ScHnX7s=
-golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/integration.go
+++ b/integration.go
@@ -85,8 +85,12 @@ type ImageURLTemplate struct {
 }
 
 type Label struct {
-	Key   string `json:"key"`
-	Value string `json:"value"`
+	Key   KeyValueName `json:"key"`
+	Value KeyValueName `json:"value"`
+}
+
+type KeyValueName struct {
+	Name	string `json:"name"`
 }
 
 type ListIntegrationOptions struct {

--- a/integration.go
+++ b/integration.go
@@ -35,6 +35,7 @@ type Integration struct {
 	Type           string        `json:"type"`
 	DefaultRoute   *DefaultRoute `json:"default_route"`
 	Templates      *Templates    `json:"templates"`
+	Labels         []*Label      `json:"labels"`
 }
 
 type DefaultRoute struct {
@@ -81,6 +82,11 @@ type MessageTemplate struct {
 
 type ImageURLTemplate struct {
 	ImageURL *string `json:"image_url"`
+}
+
+type Label struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 type ListIntegrationOptions struct {
@@ -136,6 +142,7 @@ type CreateIntegrationOptions struct {
 	Type         string        `json:"type,omitempty"`
 	Templates    *Templates    `json:"templates,omitempty"`
 	DefaultRoute *DefaultRoute `json:"default_route,omitempty"`
+	Labels       []*Label      `json:"labels,omitempty"`
 }
 
 // CreateIntegration creates integration with type, team_id and optional given name.
@@ -163,6 +170,7 @@ type UpdateIntegrationOptions struct {
 	TeamId       string        `json:"team_id"`
 	Templates    *Templates    `json:"templates,omitempty"`
 	DefaultRoute *DefaultRoute `json:"default_route,omitempty"`
+	Labels       []*Label      `json:"labels,omitempty"`
 }
 
 // UpdateIntegration updates integration with new templates, name and default route.

--- a/integration_test.go
+++ b/integration_test.go
@@ -60,6 +60,12 @@ var testIntegration = &Integration{
 			nil,
 		},
 	},
+	Labels: []*Label{
+		&Label{
+			Key: "Flip",
+			Value: "Flop",
+		},
+	},
 }
 
 var testIntegrationBody = `{
@@ -111,7 +117,13 @@ var testIntegrationBody = `{
 		  "title":null,
 		  "message":null
 	   }
-	}
+	},
+	"labels":[
+		{
+			"key": "Flip",
+			"value": "Flop"
+		}
+	]
  }`
 
 func TestCreateIntegration(t *testing.T) {

--- a/integration_test.go
+++ b/integration_test.go
@@ -62,8 +62,12 @@ var testIntegration = &Integration{
 	},
 	Labels: []*Label{
 		&Label{
-			Key: "Flip",
-			Value: "Flop",
+			Key: KeyValueName{
+				Name: "Flip",
+			},
+			Value: KeyValueName{
+				Name: "Flop",
+			},
 		},
 	},
 }
@@ -120,8 +124,12 @@ var testIntegrationBody = `{
 	},
 	"labels":[
 		{
-			"key": "Flip",
-			"value": "Flop"
+			"key": {
+				"name": "Flip"
+			},
+			"value": {
+				"name": "Flop"
+			}
 		}
 	]
  }`


### PR DESCRIPTION
Passing along labels as part of an oncall integration.

Recently added to the public API was the ability to create labels on top of an OnCall integration, meeting parity with the Web interface. This extends that same public API change further.