### PR TITLE
feat: add ScheduleFilter field to webhook types

### DIFF
--- a/webhook.go
+++ b/webhook.go
@@ -42,6 +42,7 @@ type Webhook struct {
 	Headers             *string   `json:"headers"`
 	ForwardAll          bool      `json:"forward_all"`
 	IntegrationFilter   *[]string `json:"integration_filter"`
+	ScheduleFilter      *[]string `json:"schedule_filter"`
 	IsWebhookEnabled    bool      `json:"is_webhook_enabled"`
 }
 
@@ -108,6 +109,7 @@ type CreateWebhookOptions struct {
 	Headers             *string   `json:"headers"`
 	ForwardAll          bool      `json:"forward_all"`
 	IntegrationFilter   *[]string `json:"integration_filter"`
+	ScheduleFilter      *[]string `json:"schedule_filter"`
 	IsWebhookEnabled    bool      `json:"is_webhook_enabled"`
 }
 
@@ -148,6 +150,7 @@ type UpdateWebhookOptions struct {
 	Headers             *string   `json:"headers"`
 	ForwardAll          bool      `json:"forward_all"`
 	IntegrationFilter   *[]string `json:"integration_filter"`
+	ScheduleFilter      *[]string `json:"schedule_filter"`
 	IsWebhookEnabled    bool      `json:"is_webhook_enabled"`
 }
 

--- a/webhook_test.go
+++ b/webhook_test.go
@@ -123,3 +123,46 @@ func TestGetWebhook(t *testing.T) {
 		t.Errorf("returned\n %+v\n want\n %+v\n", Webhook, want)
 	}
 }
+
+func TestGetWebhookWithScheduleFilter(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	body := `{
+	"id": "KGEFG74LU1D8L",
+	"name": "Schedule webhook",
+	"team": "T3HRAP3K3IKOP",
+	"http_method": "POST",
+	"trigger_type": "on-call changed",
+	"url": "http://test.com",
+	"preset": "schedule_webhook",
+	"schedule_filter": ["S1HRAP3K3IKOP", "S2HRAP3K3IKOP"]
+}`
+
+	mux.HandleFunc("/api/v1/webhooks/KGEFG74LU1D8L/", func(w http.ResponseWriter, r *http.Request) {
+		testRequestMethod(t, r, "GET")
+		fmt.Fprint(w, body)
+	})
+
+	options := &GetWebhookOptions{}
+	webhook, _, err := client.Webhooks.GetWebhook("KGEFG74LU1D8L", options)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	scheduleFilter := []string{"S1HRAP3K3IKOP", "S2HRAP3K3IKOP"}
+	want := &Webhook{
+		ID:             "KGEFG74LU1D8L",
+		Name:           "Schedule webhook",
+		Team:           "T3HRAP3K3IKOP",
+		HttpMethod:     "POST",
+		TriggerType:    "on-call changed",
+		Url:            "http://test.com",
+		Preset:         "schedule_webhook",
+		ScheduleFilter: &scheduleFilter,
+	}
+
+	if !reflect.DeepEqual(want, webhook) {
+		t.Errorf("returned\n %+v\n want\n %+v\n", webhook, want)
+	}
+}


### PR DESCRIPTION
## What?

Adds `ScheduleFilter *[]string` to the `Webhook`, `CreateWebhookOptions`, and `UpdateWebhookOptions` structs, supporting the new `schedule_filter` field on the OnCall public API for schedule-type webhooks.

## Why?

PR [grafana/irm#9249](https://github.com/grafana/irm/pull/9249) introduced schedule webhooks with a `schedule_filter` field that controls which schedules trigger the webhook. The public API is being updated to expose this field ([grafana/irm#9917](https://github.com/grafana/irm/pull/9917)), and this Go client needs the corresponding struct field so consumers (including the Terraform provider) can read and write it.

## How to test

- New test `TestGetWebhookWithScheduleFilter` verifies deserialization of a schedule webhook response with a non-empty `schedule_filter` array.
- All existing webhook tests continue to pass (the field defaults to `nil` when absent from the JSON response, matching the existing `IntegrationFilter` behavior).