### PR TITLE
fix: send explicit null for route escalation_chain_id

### DIFF
--- a/route.go
+++ b/route.go
@@ -30,7 +30,7 @@ type PaginatedRoutesResponse struct {
 type Route struct {
 	ID                string         `json:"id"`
 	IntegrationId     string         `json:"integration_id"`
-	EscalationChainId string         `json:"escalation_chain_id"`
+	EscalationChainId *string        `json:"escalation_chain_id"`
 	Position          int            `json:"position"`
 	RoutingRegex      string         `json:"routing_regex"`
 	RoutingType       string         `json:"routing_type"`
@@ -105,7 +105,7 @@ func (service *RouteService) GetRoute(id string, opt *GetRouteOptions) (*Route, 
 
 type CreateRouteOptions struct {
 	IntegrationId     string         `json:"integration_id,omitempty"`
-	EscalationChainId string         `json:"escalation_chain_id,omitempty"`
+	EscalationChainId *string        `json:"escalation_chain_id"`
 	Position          *int           `json:"position,omitempty"`
 	RoutingRegex      string         `json:"routing_regex,omitempty"`
 	RoutingType       string         `json:"routing_type,omitempty"`
@@ -138,7 +138,7 @@ func (service *RouteService) CreateRoute(opt *CreateRouteOptions) (*Route, *http
 }
 
 type UpdateRouteOptions struct {
-	EscalationChainId string         `json:"escalation_chain_id,omitempty"`
+	EscalationChainId *string        `json:"escalation_chain_id"`
 	Position          *int           `json:"position,omitempty"`
 	Slack             *SlackRoute    `json:"slack,omitempty"`
 	Telegram          *TelegramRoute `json:"telegram,omitempty"`

--- a/route_test.go
+++ b/route_test.go
@@ -1,9 +1,12 @@
 package aapi
 
 import (
+	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -89,6 +92,115 @@ func TestCreateRoute(t *testing.T) {
 
 	if !reflect.DeepEqual(want, route) {
 		t.Errorf("returned\n %+v\n want\n %+v\n", route, want)
+	}
+}
+
+func TestCreateRouteOptionsJSONEscalationChainId(t *testing.T) {
+	t.Run("null", func(t *testing.T) {
+		opt := &CreateRouteOptions{
+			IntegrationId: "CGEXJ922S7TXQ",
+			RoutingRegex:  "us-west",
+		}
+
+		data, err := json.Marshal(opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(string(data), `"escalation_chain_id":null`) {
+			t.Fatalf("expected explicit null escalation_chain_id, got %s", data)
+		}
+	})
+
+	t.Run("id", func(t *testing.T) {
+		chainID := "RIYGUJXCPFHXY"
+		opt := &CreateRouteOptions{
+			IntegrationId:     "CGEXJ922S7TXQ",
+			RoutingRegex:      "us-west",
+			EscalationChainId: &chainID,
+		}
+
+		data, err := json.Marshal(opt)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if !strings.Contains(string(data), `"escalation_chain_id":"RIYGUJXCPFHXY"`) {
+			t.Fatalf("expected escalation_chain_id in payload, got %s", data)
+		}
+	})
+}
+
+func TestCreateRouteWithoutEscalationChain(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v1/routes/", func(w http.ResponseWriter, r *http.Request) {
+		testRequestMethod(t, r, "POST")
+
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !strings.Contains(string(body), `"escalation_chain_id":null`) {
+			t.Fatalf("expected explicit null escalation_chain_id, got %s", body)
+		}
+
+		fmt.Fprint(w, `{
+			"id": "RH2V5FYIPYJ1M",
+			"integration_id": "CGEXJ922S7TXQ",
+			"escalation_chain_id": null,
+			"routing_regex": "us-west",
+			"routing_type": "regex",
+			"position": 0,
+			"is_the_last_route": false,
+			"slack": {"channel_id": null, "enabled": true},
+			"telegram": {"id": null, "enabled": false},
+			"msteams": {"id": null, "enabled": false}
+		}`)
+	})
+
+	createOptions := &CreateRouteOptions{
+		IntegrationId: "CGEXJ922S7TXQ",
+		RoutingRegex:  "us-west",
+	}
+	route, _, err := client.Routes.CreateRoute(createOptions)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if route.EscalationChainId != nil {
+		t.Fatalf("expected nil escalation chain id, got %v", route.EscalationChainId)
+	}
+}
+
+func TestGetRouteWithoutEscalationChain(t *testing.T) {
+	mux, server, client := setup(t)
+	defer teardown(server)
+
+	mux.HandleFunc("/api/v1/routes/RH2V5FYIPYJ1M/", func(w http.ResponseWriter, r *http.Request) {
+		testRequestMethod(t, r, "GET")
+		fmt.Fprint(w, `{
+			"id": "RH2V5FYIPYJ1M",
+			"integration_id": "CGEXJ922S7TXQ",
+			"escalation_chain_id": null,
+			"routing_regex": "us-west",
+			"routing_type": "regex",
+			"position": 0,
+			"is_the_last_route": false,
+			"slack": {"channel_id": null, "enabled": true},
+			"telegram": {"id": null, "enabled": false},
+			"msteams": {"id": null, "enabled": false}
+		}`)
+	})
+
+	route, _, err := client.Routes.GetRoute("RH2V5FYIPYJ1M", &GetRouteOptions{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if route.EscalationChainId != nil {
+		t.Fatalf("expected nil escalation chain id, got %v", route.EscalationChainId)
 	}
 }
 


### PR DESCRIPTION
## What?
- Change `Route.EscalationChainId`, `CreateRouteOptions.EscalationChainId`, and `UpdateRouteOptions.EscalationChainId` from `string` with `omitempty` to `*string` without `omitempty`.
- When no escalation chain is configured, the client now sends `"escalation_chain_id": null` in create/update payloads instead of omitting the field.
- Add tests covering JSON marshaling, create requests, and get responses for null escalation chain IDs.

## Why?
The OnCall routes HTTP API accepts routes without an escalation chain when `escalation_chain_id` is explicitly `null`. Omitting the field returns `400 {escalation_chain_id: [This field is required.]}`.

This blocks `grafana_oncall_route` in terraform-provider-grafana from managing chain-less routes (support-escalations#22419 / terraform-provider-grafana#2797). The provider already makes `escalation_chain_id` optional; it needs a released client that encodes null correctly.

## How to test
- `go test ./... -run Route -v`
- After release, bump terraform-provider-grafana to the new tag and re-run `TestAccOnCallRoute_withoutEscalationChain` against OnCall Cloud.

## Notes to reviewers
- This is a breaking API change for Go callers: `EscalationChainId` is now `*string` on route types. terraform-provider-grafana will need a follow-up PR after this is tagged.
- Matches the existing pattern used by `DefaultRoute.EscalationChainId` in `integration.go`.