### PR TITLE
feat: resolve OnCall backend URL via grafana-irm-app autodiscovery

### DIFF
--- a/client.go
+++ b/client.go
@@ -1,6 +1,7 @@
 package aapi
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -9,6 +10,8 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
+	"time"
 
 	"github.com/google/go-querystring/query"
 	"github.com/hashicorp/go-retryablehttp"
@@ -17,6 +20,16 @@ import (
 const (
 	apiVersionPath   = "api/v1/"
 	defaultUserAgent = "amixr-api-go-client"
+
+	// grafanaIRMAppSettingsPath is the Grafana API path that exposes the
+	// grafana-irm-app plugin settings, whose jsonData.onCallApiUrl holds the
+	// OnCall backend URL provisioned for the stack.
+	grafanaIRMAppSettingsPath = "api/plugins/grafana-irm-app/settings"
+
+	// defaultOnCallURL is the last-resort OnCall backend URL used when the URL
+	// can neither be discovered from the grafana-irm-app plugin settings nor
+	// provided explicitly.
+	defaultOnCallURL = "https://oncall-prod-us-central-0.grafana.net/oncall"
 )
 
 type ListOptions struct {
@@ -36,6 +49,16 @@ type Client struct {
 	baseURL    *url.URL
 	grafanaURL *url.URL
 	UserAgent  string
+
+	// Lazy OnCall backend-URL resolution. These are only used by clients built
+	// with NewWithGrafanaAutodiscovery; for the other constructors baseURL is
+	// set eagerly and these remain zero-valued (resolution never runs).
+	grafanaAuthToken  string     // auth used for the grafana-irm-app settings lookup
+	configuredBaseURL string     // explicit OnCall URL fallback (e.g. oncall_url)
+	baseURLOnce       sync.Once  // guards a single resolution attempt
+	warnMu            sync.Mutex // guards warnings
+	warnings          []string   // resolution warnings, drained via Warnings()
+
 	// List of Services. Keep in sync with func newClient
 	Alerts                *AlertService
 	AlertGroups           *AlertGroupService
@@ -57,8 +80,11 @@ func NewWithGrafanaURL(base_url, token, grafana_url string) (*Client, error) {
 	if base_url == "" {
 		return nil, fmt.Errorf("BaseUrl required")
 	}
-	client, err := newClient(base_url, grafana_url)
+	client, err := newClient(grafana_url)
 	if err != nil {
+		return nil, err
+	}
+	if err := client.setBaseURL(base_url); err != nil {
 		return nil, err
 	}
 	client.token = token
@@ -69,27 +95,49 @@ func New(base_url, token string) (*Client, error) {
 	if base_url == "" {
 		return nil, fmt.Errorf("BaseUrl required")
 	}
-	client, err := newClient(base_url, "")
+	client, err := newClient("")
 	if err != nil {
+		return nil, err
+	}
+	if err := client.setBaseURL(base_url); err != nil {
 		return nil, err
 	}
 	client.token = token
 	return client, nil
 }
 
-func newClient(url, grafana_url string) (*Client, error) {
+// NewWithGrafanaAutodiscovery creates a client whose OnCall backend URL is
+// resolved lazily, on first request (or an explicit EnsureBaseURL call), rather
+// than at construction. No network call is made here.
+//
+// On first use the client resolves its base URL in this order:
+//  1. the URL provisioned in the grafana-irm-app plugin settings, looked up via
+//     grafanaURL + grafanaAuthToken;
+//  2. oncallURL, if provided;
+//  3. a built-in default.
+//
+// grafanaAuthToken authenticates the plugin-settings lookup (a Grafana API
+// call); it follows the same convention as the Grafana provider's auth field
+// ("user:password" for basic auth, otherwise a bearer token). oncallToken
+// authenticates OnCall API calls and may differ from grafanaAuthToken.
+func NewWithGrafanaAutodiscovery(grafanaURL, grafanaAuthToken, oncallToken, oncallURL string) (*Client, error) {
+	client, err := newClient(grafanaURL)
+	if err != nil {
+		return nil, err
+	}
+	client.token = oncallToken
+	client.grafanaAuthToken = grafanaAuthToken
+	client.configuredBaseURL = oncallURL
+	return client, nil
+}
+
+func newClient(grafana_url string) (*Client, error) {
 	c := &Client{}
 
 	// retryablehttp.Client will retry up to 4 times on recoverable errors (429, 5xx, and low-level network errors)
 	c.client = retryablehttp.NewClient()
 
-	// Set the default base URL. _ suppress error handling
-	err := c.setBaseURL(url)
-	if err != nil {
-		return nil, err
-	}
-
-	err = c.setGrafanaURL(grafana_url)
+	err := c.setGrafanaURL(grafana_url)
 	if err != nil {
 		return nil, err
 	}
@@ -147,6 +195,15 @@ func (c *Client) setGrafanaURL(urlStr string) error {
 }
 
 func (c *Client) NewRequest(method, path string, opt interface{}) (*retryablehttp.Request, error) {
+	// Safety net for autodiscovery clients whose caller never invoked
+	// EnsureBaseURL: resolve lazily here. For clients built with New /
+	// NewWithGrafanaURL the base URL is already set and this is a no-op.
+	if c.baseURL == nil {
+		if err := c.EnsureBaseURL(context.Background()); err != nil {
+			return nil, err
+		}
+	}
+
 	u := *c.baseURL
 	unescaped, err := url.PathUnescape(path)
 	if err != nil {
@@ -302,4 +359,133 @@ func (c *Client) GrafanaURL() *url.URL {
 	}
 	u := *c.grafanaURL
 	return &u
+}
+
+// EnsureBaseURL resolves the OnCall backend URL if it has not been resolved yet.
+// It is safe to call multiple times and concurrently; resolution runs at most
+// once. Resolution is best-effort and always yields a usable URL (falling back
+// to an explicit OnCall URL or a built-in default), so it returns a nil error
+// today; the error is retained for forward compatibility. Clients constructed
+// with a concrete base URL (New / NewWithGrafanaURL) treat this as a no-op.
+func (c *Client) EnsureBaseURL(ctx context.Context) error {
+	if c.baseURL != nil {
+		return nil
+	}
+	c.baseURLOnce.Do(func() {
+		c.resolveBaseURL(ctx)
+	})
+	return nil
+}
+
+// resolveBaseURL determines the OnCall backend URL: it prefers the URL
+// provisioned in the grafana-irm-app plugin settings, then an explicitly
+// configured URL, then the built-in default. A failed plugin lookup is recorded
+// as a warning (see Warnings) and resolution falls through.
+func (c *Client) resolveBaseURL(ctx context.Context) {
+	if c.grafanaURL != nil && c.grafanaAuthToken != "" {
+		if pluginURL, err := c.fetchOnCallURLFromPlugin(ctx); err != nil {
+			c.addWarning(fmt.Sprintf(
+				"Could not determine the OnCall backend URL from the grafana-irm-app plugin settings: %s. "+
+					"Ensure the Grafana IRM/OnCall app is installed for this stack and that the token has the plugins.app:access permission, "+
+					"or set the oncall_url provider attribute explicitly. Falling back to oncall_url or the default OnCall URL.",
+				err,
+			))
+		} else if pluginURL != "" {
+			if err := c.setBaseURL(pluginURL); err == nil {
+				return
+			}
+		}
+	}
+
+	if c.configuredBaseURL != "" {
+		if err := c.setBaseURL(c.configuredBaseURL); err == nil {
+			return
+		}
+	}
+
+	// Last resort: the historical default. setBaseURL only fails on a parse
+	// error, which cannot happen for this constant.
+	_ = c.setBaseURL(defaultOnCallURL)
+}
+
+// fetchOnCallURLFromPlugin reads jsonData.onCallApiUrl from the grafana-irm-app
+// plugin settings at GET {grafanaURL}/api/plugins/grafana-irm-app/settings.
+func (c *Client) fetchOnCallURLFromPlugin(ctx context.Context) (string, error) {
+	settingsURL, err := url.JoinPath(c.grafanaURL.String(), grafanaIRMAppSettingsPath)
+	if err != nil {
+		return "", fmt.Errorf("failed to build plugin settings URL: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, settingsURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to build plugin settings request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+	if c.UserAgent != "" {
+		req.Header.Set("User-Agent", c.UserAgent)
+	}
+	// Grafana auth follows the provider convention: "user:password" -> basic
+	// auth, otherwise a bearer token. "anonymous"/empty -> no auth header.
+	if parts := strings.SplitN(c.grafanaAuthToken, ":", 2); len(parts) == 2 {
+		req.SetBasicAuth(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
+	} else if token := strings.TrimSpace(parts[0]); token != "" && token != "anonymous" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+
+	resp, err := pluginSettingsHTTPClient().Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to request plugin settings: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("plugin settings request returned status %d", resp.StatusCode)
+	}
+
+	var settings struct {
+		JSONData struct {
+			OnCallAPIURL string `json:"onCallApiUrl"`
+		} `json:"jsonData"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&settings); err != nil {
+		return "", fmt.Errorf("failed to decode plugin settings response: %w", err)
+	}
+	if settings.JSONData.OnCallAPIURL == "" {
+		return "", fmt.Errorf("grafana-irm-app plugin settings did not contain an onCallApiUrl")
+	}
+	return settings.JSONData.OnCallAPIURL, nil
+}
+
+// pluginSettingsHTTPClient returns a short-lived HTTP client for the best-effort
+// plugin-settings lookup. Retries are limited so a missing plugin or unreachable
+// Grafana fails fast instead of stalling the first OnCall request.
+func pluginSettingsHTTPClient() *http.Client {
+	rc := retryablehttp.NewClient()
+	rc.RetryMax = 2
+	rc.Logger = nil
+	return rc.StandardClient()
+}
+
+func (c *Client) addWarning(msg string) {
+	c.warnMu.Lock()
+	defer c.warnMu.Unlock()
+	c.warnings = append(c.warnings, msg)
+}
+
+// Warnings returns and clears any warnings accumulated during OnCall URL
+// resolution (for example, a failed plugin lookup that fell back to a default).
+// Because it drains, the warnings surface only once even if read by multiple
+// callers.
+func (c *Client) Warnings() []string {
+	c.warnMu.Lock()
+	defer c.warnMu.Unlock()
+	if len(c.warnings) == 0 {
+		return nil
+	}
+	out := c.warnings
+	c.warnings = nil
+	return out
 }

--- a/client.go
+++ b/client.go
@@ -100,11 +100,15 @@ func New(base_url, token string) (*Client, error) {
 // resolved lazily on first request (see EnsureBaseURL): from the grafana-irm-app
 // plugin settings, then oncallURL, then a built-in default. grafanaAuthToken
 // authenticates the plugin-settings lookup ("user:password" for basic auth,
-// otherwise a bearer token); oncallToken authenticates OnCall API calls.
+// otherwise a bearer token); oncallToken authenticates OnCall API calls, and
+// falls back to grafanaAuthToken when empty.
 func NewWithGrafanaAutodiscovery(grafanaURL, grafanaAuthToken, oncallToken, oncallURL string) (*Client, error) {
 	client, err := newClient(grafanaURL)
 	if err != nil {
 		return nil, err
+	}
+	if oncallToken == "" {
+		oncallToken = grafanaAuthToken
 	}
 	client.token = oncallToken
 	client.grafanaAuthToken = grafanaAuthToken

--- a/client.go
+++ b/client.go
@@ -18,18 +18,10 @@ import (
 )
 
 const (
-	apiVersionPath   = "api/v1/"
-	defaultUserAgent = "amixr-api-go-client"
-
-	// grafanaIRMAppSettingsPath is the Grafana API path that exposes the
-	// grafana-irm-app plugin settings, whose jsonData.onCallApiUrl holds the
-	// OnCall backend URL provisioned for the stack.
+	apiVersionPath            = "api/v1/"
+	defaultUserAgent          = "amixr-api-go-client"
 	grafanaIRMAppSettingsPath = "api/plugins/grafana-irm-app/settings"
-
-	// defaultOnCallURL is the last-resort OnCall backend URL used when the URL
-	// can neither be discovered from the grafana-irm-app plugin settings nor
-	// provided explicitly.
-	defaultOnCallURL = "https://oncall-prod-us-central-0.grafana.net/oncall"
+	defaultOnCallURL          = "https://oncall-prod-us-central-0.grafana.net/oncall"
 )
 
 type ListOptions struct {
@@ -50,14 +42,12 @@ type Client struct {
 	grafanaURL *url.URL
 	UserAgent  string
 
-	// Lazy OnCall backend-URL resolution. These are only used by clients built
-	// with NewWithGrafanaAutodiscovery; for the other constructors baseURL is
-	// set eagerly and these remain zero-valued (resolution never runs).
-	grafanaAuthToken  string     // auth used for the grafana-irm-app settings lookup
-	configuredBaseURL string     // explicit OnCall URL fallback (e.g. oncall_url)
-	baseURLOnce       sync.Once  // guards a single resolution attempt
-	warnMu            sync.Mutex // guards warnings
-	warnings          []string   // resolution warnings, drained via Warnings()
+	// Set only by NewWithGrafanaAutodiscovery; used for lazy base-URL resolution.
+	grafanaAuthToken  string
+	configuredBaseURL string
+	baseURLOnce       sync.Once
+	warnMu            sync.Mutex
+	warnings          []string
 
 	// List of Services. Keep in sync with func newClient
 	Alerts                *AlertService
@@ -107,19 +97,10 @@ func New(base_url, token string) (*Client, error) {
 }
 
 // NewWithGrafanaAutodiscovery creates a client whose OnCall backend URL is
-// resolved lazily, on first request (or an explicit EnsureBaseURL call), rather
-// than at construction. No network call is made here.
-//
-// On first use the client resolves its base URL in this order:
-//  1. the URL provisioned in the grafana-irm-app plugin settings, looked up via
-//     grafanaURL + grafanaAuthToken;
-//  2. oncallURL, if provided;
-//  3. a built-in default.
-//
-// grafanaAuthToken authenticates the plugin-settings lookup (a Grafana API
-// call); it follows the same convention as the Grafana provider's auth field
-// ("user:password" for basic auth, otherwise a bearer token). oncallToken
-// authenticates OnCall API calls and may differ from grafanaAuthToken.
+// resolved lazily on first request (see EnsureBaseURL): from the grafana-irm-app
+// plugin settings, then oncallURL, then a built-in default. grafanaAuthToken
+// authenticates the plugin-settings lookup ("user:password" for basic auth,
+// otherwise a bearer token); oncallToken authenticates OnCall API calls.
 func NewWithGrafanaAutodiscovery(grafanaURL, grafanaAuthToken, oncallToken, oncallURL string) (*Client, error) {
 	client, err := newClient(grafanaURL)
 	if err != nil {
@@ -195,9 +176,7 @@ func (c *Client) setGrafanaURL(urlStr string) error {
 }
 
 func (c *Client) NewRequest(method, path string, opt interface{}) (*retryablehttp.Request, error) {
-	// Safety net for autodiscovery clients whose caller never invoked
-	// EnsureBaseURL: resolve lazily here. For clients built with New /
-	// NewWithGrafanaURL the base URL is already set and this is a no-op.
+	// Resolve lazily if a caller never called EnsureBaseURL; a no-op once set.
 	if c.baseURL == nil {
 		if err := c.EnsureBaseURL(context.Background()); err != nil {
 			return nil, err
@@ -363,10 +342,8 @@ func (c *Client) GrafanaURL() *url.URL {
 
 // EnsureBaseURL resolves the OnCall backend URL if it has not been resolved yet.
 // It is safe to call multiple times and concurrently; resolution runs at most
-// once. Resolution is best-effort and always yields a usable URL (falling back
-// to an explicit OnCall URL or a built-in default), so it returns a nil error
-// today; the error is retained for forward compatibility. Clients constructed
-// with a concrete base URL (New / NewWithGrafanaURL) treat this as a no-op.
+// once and is a no-op for clients constructed with a concrete base URL. The
+// error return is reserved for future use and is always nil today.
 func (c *Client) EnsureBaseURL(ctx context.Context) error {
 	if c.baseURL != nil {
 		return nil
@@ -377,10 +354,6 @@ func (c *Client) EnsureBaseURL(ctx context.Context) error {
 	return nil
 }
 
-// resolveBaseURL determines the OnCall backend URL: it prefers the URL
-// provisioned in the grafana-irm-app plugin settings, then an explicitly
-// configured URL, then the built-in default. A failed plugin lookup is recorded
-// as a warning (see Warnings) and resolution falls through.
 func (c *Client) resolveBaseURL(ctx context.Context) {
 	if c.grafanaURL != nil && c.grafanaAuthToken != "" {
 		if pluginURL, err := c.fetchOnCallURLFromPlugin(ctx); err != nil {
@@ -403,8 +376,6 @@ func (c *Client) resolveBaseURL(ctx context.Context) {
 		}
 	}
 
-	// Last resort: the historical default. setBaseURL only fails on a parse
-	// error, which cannot happen for this constant.
 	_ = c.setBaseURL(defaultOnCallURL)
 }
 
@@ -427,8 +398,7 @@ func (c *Client) fetchOnCallURLFromPlugin(ctx context.Context) (string, error) {
 	if c.UserAgent != "" {
 		req.Header.Set("User-Agent", c.UserAgent)
 	}
-	// Grafana auth follows the provider convention: "user:password" -> basic
-	// auth, otherwise a bearer token. "anonymous"/empty -> no auth header.
+	// "user:password" -> basic auth, otherwise a bearer token.
 	if parts := strings.SplitN(c.grafanaAuthToken, ":", 2); len(parts) == 2 {
 		req.SetBasicAuth(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
 	} else if token := strings.TrimSpace(parts[0]); token != "" && token != "anonymous" {
@@ -459,9 +429,8 @@ func (c *Client) fetchOnCallURLFromPlugin(ctx context.Context) (string, error) {
 	return settings.JSONData.OnCallAPIURL, nil
 }
 
-// pluginSettingsHTTPClient returns a short-lived HTTP client for the best-effort
-// plugin-settings lookup. Retries are limited so a missing plugin or unreachable
-// Grafana fails fast instead of stalling the first OnCall request.
+// pluginSettingsHTTPClient returns a low-retry HTTP client for the best-effort
+// plugin-settings lookup so a missing plugin or unreachable Grafana fails fast.
 func pluginSettingsHTTPClient() *http.Client {
 	rc := retryablehttp.NewClient()
 	rc.RetryMax = 2
@@ -476,9 +445,7 @@ func (c *Client) addWarning(msg string) {
 }
 
 // Warnings returns and clears any warnings accumulated during OnCall URL
-// resolution (for example, a failed plugin lookup that fell back to a default).
-// Because it drains, the warnings surface only once even if read by multiple
-// callers.
+// resolution (e.g. a failed plugin lookup that fell back to a default).
 func (c *Client) Warnings() []string {
 	c.warnMu.Lock()
 	defer c.warnMu.Unlock()

--- a/client.go
+++ b/client.go
@@ -98,10 +98,10 @@ func New(base_url, token string) (*Client, error) {
 
 // NewWithGrafanaAutodiscovery creates a client whose OnCall backend URL is
 // resolved lazily on first request (see EnsureBaseURL): from the grafana-irm-app
-// plugin settings, then oncallURL, then a built-in default. grafanaAuthToken
-// authenticates the plugin-settings lookup ("user:password" for basic auth,
-// otherwise a bearer token); oncallToken authenticates OnCall API calls, and
-// falls back to grafanaAuthToken when empty.
+// plugin settings, then oncallURL, then a built-in default. grafanaAuthToken is
+// a Grafana service account token; it authenticates the plugin-settings lookup.
+// oncallToken authenticates OnCall API calls and falls back to grafanaAuthToken
+// when empty.
 func NewWithGrafanaAutodiscovery(grafanaURL, grafanaAuthToken, oncallToken, oncallURL string) (*Client, error) {
 	client, err := newClient(grafanaURL)
 	if err != nil {
@@ -402,10 +402,7 @@ func (c *Client) fetchOnCallURLFromPlugin(ctx context.Context) (string, error) {
 	if c.UserAgent != "" {
 		req.Header.Set("User-Agent", c.UserAgent)
 	}
-	// "user:password" -> basic auth, otherwise a bearer token.
-	if parts := strings.SplitN(c.grafanaAuthToken, ":", 2); len(parts) == 2 {
-		req.SetBasicAuth(strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]))
-	} else if token := strings.TrimSpace(parts[0]); token != "" && token != "anonymous" {
+	if token := strings.TrimSpace(c.grafanaAuthToken); token != "" && token != "anonymous" {
 		req.Header.Set("Authorization", "Bearer "+token)
 	}
 

--- a/client_autodiscovery_test.go
+++ b/client_autodiscovery_test.go
@@ -218,34 +218,6 @@ func TestAutodiscoveryOnCallTokenFallsBackToGrafanaToken(t *testing.T) {
 	}
 }
 
-func TestAutodiscoveryBasicAuthForLookup(t *testing.T) {
-	mux := http.NewServeMux()
-	server := httptest.NewServer(mux)
-	defer server.Close()
-
-	var user, pass string
-	var ok bool
-	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", func(w http.ResponseWriter, r *http.Request) {
-		user, pass, ok = r.BasicAuth()
-		w.Header().Set("Content-Type", "application/json")
-		_ = json.NewEncoder(w).Encode(map[string]any{
-			"jsonData": map[string]any{"onCallApiUrl": server.URL + "/oncall"},
-		})
-	})
-
-	c, err := NewWithGrafanaAutodiscovery(server.URL, "admin:secret", "oncall_token", "")
-	if err != nil {
-		t.Fatalf("constructor error: %v", err)
-	}
-	if err := c.EnsureBaseURL(context.Background()); err != nil {
-		t.Fatalf("EnsureBaseURL error: %v", err)
-	}
-
-	if !ok || user != "admin" || pass != "secret" {
-		t.Errorf("discovery basic auth = (%q,%q,ok=%v), want (admin,secret,true)", user, pass, ok)
-	}
-}
-
 func TestAutodiscoveryLazyOnNewRequest(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/client_autodiscovery_test.go
+++ b/client_autodiscovery_test.go
@@ -180,6 +180,44 @@ func TestAutodiscoveryTwoTokens(t *testing.T) {
 	}
 }
 
+func TestAutodiscoveryOnCallTokenFallsBackToGrafanaToken(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonData": map[string]any{"onCallApiUrl": server.URL},
+		})
+	})
+
+	var apiAuth string
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		apiAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
+	})
+
+	// Empty OnCall token -> OnCall API calls use the Grafana auth token.
+	c, err := NewWithGrafanaAutodiscovery(server.URL, "glsa_grafana", "", "")
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+
+	req, err := c.NewRequest("GET", "users", nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if _, err := c.Do(req, nil); err != nil {
+		t.Fatalf("Do error: %v", err)
+	}
+
+	if apiAuth != "glsa_grafana" {
+		t.Errorf("OnCall API call used Authorization %q, want %q", apiAuth, "glsa_grafana")
+	}
+}
+
 func TestAutodiscoveryBasicAuthForLookup(t *testing.T) {
 	mux := http.NewServeMux()
 	server := httptest.NewServer(mux)

--- a/client_autodiscovery_test.go
+++ b/client_autodiscovery_test.go
@@ -1,0 +1,230 @@
+package aapi
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// settingsHandler writes a grafana-irm-app plugin settings response whose
+// jsonData.onCallApiUrl is onCallURL.
+func settingsHandler(onCallURL string, capture *http.Header) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if capture != nil {
+			*capture = r.Header.Clone()
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonData": map[string]any{"onCallApiUrl": onCallURL},
+		})
+	}
+}
+
+func expectedBaseURL(rawURL string) string {
+	return rawURL + "/" + apiVersionPath
+}
+
+func TestAutodiscoverySuccess(t *testing.T) {
+	mux := http.NewServeMux()
+	var gotHeaders http.Header
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", settingsHandler(server.URL+"/oncall", &gotHeaders))
+
+	c, err := NewWithGrafanaAutodiscovery(server.URL, "glsa_grafana", "oncall_token", "")
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+
+	// No network at construction.
+	if c.baseURL != nil {
+		t.Fatal("baseURL should be unresolved before EnsureBaseURL")
+	}
+
+	if err := c.EnsureBaseURL(context.Background()); err != nil {
+		t.Fatalf("EnsureBaseURL error: %v", err)
+	}
+
+	want := expectedBaseURL(server.URL + "/oncall")
+	if got := c.BaseURL().String(); got != want {
+		t.Errorf("BaseURL = %s, want %s", got, want)
+	}
+	if w := c.Warnings(); len(w) != 0 {
+		t.Errorf("expected no warnings, got %v", w)
+	}
+	if got := gotHeaders.Get("Authorization"); got != "Bearer glsa_grafana" {
+		t.Errorf("discovery Authorization = %q, want %q", got, "Bearer glsa_grafana")
+	}
+}
+
+func TestAutodiscoveryFallbackToExplicitURLOnLookupFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	explicit := "https://oncall.example.com/oncall"
+	c, err := NewWithGrafanaAutodiscovery(server.URL, "glsa_grafana", "oncall_token", explicit)
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+
+	if err := c.EnsureBaseURL(context.Background()); err != nil {
+		t.Fatalf("EnsureBaseURL error: %v", err)
+	}
+
+	if got, want := c.BaseURL().String(), expectedBaseURL(explicit); got != want {
+		t.Errorf("BaseURL = %s, want %s", got, want)
+	}
+
+	warnings := c.Warnings()
+	if len(warnings) != 1 {
+		t.Fatalf("expected 1 warning, got %d: %v", len(warnings), warnings)
+	}
+	// Warnings drain: a second read returns nothing.
+	if again := c.Warnings(); len(again) != 0 {
+		t.Errorf("warnings should drain, got %v", again)
+	}
+}
+
+func TestAutodiscoveryFallbackToDefaultOnLookupFailure(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	})
+
+	c, err := NewWithGrafanaAutodiscovery(server.URL, "glsa_grafana", "oncall_token", "")
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+
+	if err := c.EnsureBaseURL(context.Background()); err != nil {
+		t.Fatalf("EnsureBaseURL error: %v", err)
+	}
+
+	if got, want := c.BaseURL().String(), expectedBaseURL(defaultOnCallURL); got != want {
+		t.Errorf("BaseURL = %s, want %s", got, want)
+	}
+	if w := c.Warnings(); len(w) != 1 {
+		t.Errorf("expected 1 warning, got %v", w)
+	}
+}
+
+func TestAutodiscoveryExplicitURLWithoutGrafana(t *testing.T) {
+	// No grafana URL/auth -> no discovery attempt, no warning, explicit URL used.
+	explicit := "https://oncall.example.com/oncall"
+	c, err := NewWithGrafanaAutodiscovery("", "", "oncall_token", explicit)
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+
+	if err := c.EnsureBaseURL(context.Background()); err != nil {
+		t.Fatalf("EnsureBaseURL error: %v", err)
+	}
+
+	if got, want := c.BaseURL().String(), expectedBaseURL(explicit); got != want {
+		t.Errorf("BaseURL = %s, want %s", got, want)
+	}
+	if w := c.Warnings(); len(w) != 0 {
+		t.Errorf("expected no warnings, got %v", w)
+	}
+}
+
+func TestAutodiscoveryTwoTokens(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	var discoveryAuth string
+	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", func(w http.ResponseWriter, r *http.Request) {
+		discoveryAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonData": map[string]any{"onCallApiUrl": server.URL},
+		})
+	})
+
+	var apiAuth string
+	mux.HandleFunc("/api/v1/users", func(w http.ResponseWriter, r *http.Request) {
+		apiAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"count":0,"results":[]}`))
+	})
+
+	c, err := NewWithGrafanaAutodiscovery(server.URL, "glsa_grafana", "oncall_token", "")
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+
+	req, err := c.NewRequest("GET", "users", nil)
+	if err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if _, err := c.Do(req, nil); err != nil {
+		t.Fatalf("Do error: %v", err)
+	}
+
+	if discoveryAuth != "Bearer glsa_grafana" {
+		t.Errorf("discovery used Authorization %q, want %q", discoveryAuth, "Bearer glsa_grafana")
+	}
+	// OnCall API calls use the raw OnCall token (existing amixr convention).
+	if apiAuth != "oncall_token" {
+		t.Errorf("OnCall API call used Authorization %q, want %q", apiAuth, "oncall_token")
+	}
+}
+
+func TestAutodiscoveryBasicAuthForLookup(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	var user, pass string
+	var ok bool
+	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", func(w http.ResponseWriter, r *http.Request) {
+		user, pass, ok = r.BasicAuth()
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"jsonData": map[string]any{"onCallApiUrl": server.URL + "/oncall"},
+		})
+	})
+
+	c, err := NewWithGrafanaAutodiscovery(server.URL, "admin:secret", "oncall_token", "")
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+	if err := c.EnsureBaseURL(context.Background()); err != nil {
+		t.Fatalf("EnsureBaseURL error: %v", err)
+	}
+
+	if !ok || user != "admin" || pass != "secret" {
+		t.Errorf("discovery basic auth = (%q,%q,ok=%v), want (admin,secret,true)", user, pass, ok)
+	}
+}
+
+func TestAutodiscoveryLazyOnNewRequest(t *testing.T) {
+	mux := http.NewServeMux()
+	server := httptest.NewServer(mux)
+	defer server.Close()
+	mux.HandleFunc("/api/plugins/grafana-irm-app/settings", settingsHandler(server.URL+"/oncall", nil))
+
+	c, err := NewWithGrafanaAutodiscovery(server.URL, "glsa_grafana", "oncall_token", "")
+	if err != nil {
+		t.Fatalf("constructor error: %v", err)
+	}
+
+	// Never call EnsureBaseURL; NewRequest must resolve the base URL itself.
+	if _, err := c.NewRequest("GET", "users", nil); err != nil {
+		t.Fatalf("NewRequest error: %v", err)
+	}
+	if got, want := c.BaseURL().String(), expectedBaseURL(server.URL+"/oncall"); got != want {
+		t.Errorf("BaseURL = %s, want %s", got, want)
+	}
+	_ = fmt.Sprint(c.GrafanaURL())
+}


### PR DESCRIPTION
## What?

Adds `NewWithGrafanaAutodiscovery`, a new constructor whose OnCall backend URL is determined **lazily on first request** instead of at construction time. On first use the client resolves its base URL in this order:

1. The URL provisioned in the `grafana-irm-app` plugin settings — looked up via `GET {grafanaURL}/api/plugins/grafana-irm-app/settings` → `jsonData.onCallApiUrl`.
2. An explicitly provided OnCall URL, if set.
3. A built-in default.

The recommended setup is a Grafana URL plus a **Grafana service account token**. That token is used two ways: it authenticates the plugin-settings lookup (sent as a bearer token to the Grafana API), and — unless a separate OnCall token is supplied — it also authenticates OnCall API calls. A failed lookup is recorded as a warning (retrievable once via `Warnings()`), and resolution falls through to the fallbacks.

New surface:
- `NewWithGrafanaAutodiscovery(grafanaURL, grafanaAuthToken, oncallToken, oncallURL)`
- `(*Client).EnsureBaseURL(ctx)` — idempotent, resolves at most once
- `(*Client).Warnings()` — drains resolution warnings

### Behavior by `NewWithGrafanaAutodiscovery` inputs

The plugin-settings lookup is attempted only when **both** `grafanaURL` and `grafanaAuthToken` are set. "Grafana token" below means OnCall calls authenticate with `grafanaAuthToken` (the fallback when `oncallToken` is empty).

| Inputs provided | Resolved OnCall URL | OnCall call auth | Warning |
|---|---|---|---|
| `grafanaURL` + `grafanaAuthToken`, lookup OK | plugin `onCallApiUrl` | Grafana token | none |
| `grafanaURL` + `grafanaAuthToken` + `oncallToken`, lookup OK | plugin `onCallApiUrl` | `oncallToken` | none |
| `grafanaURL` + `grafanaAuthToken` + `oncallURL`, lookup OK | plugin `onCallApiUrl` (`oncallURL` ignored) | Grafana token | none |
| `grafanaURL` + `grafanaAuthToken` + `oncallURL`, lookup fails | `oncallURL` | Grafana token | yes — lookup failed, using fallback |
| `grafanaURL` + `grafanaAuthToken`, lookup fails, no `oncallURL` | built-in default | Grafana token | yes — lookup failed, using default |
| No `grafanaURL`/`grafanaAuthToken`, `oncallToken` (± `oncallURL`) | `oncallURL` if set, else built-in default | `oncallToken` | none (no lookup attempted) |

## Why?

The Grafana Terraform provider previously had to know the regional OnCall backend URL up front or fall back to a hardcoded `us-central` default, which silently produced wrong results for stacks in other regions. Moving the discovery + fallback chain into this client lets the provider construct an OnCall client with no network call and no URL guessing; the correct regional URL is discovered on first use. It also keeps the provider's configuration phase free of network calls and diagnostics.

## How to test

- New `client_autodiscovery_test.go` covers (httptest-based): discovery success, fallback-to-explicit-URL on lookup failure (with a single drained warning), fallback-to-default, explicit URL without Grafana, two-token usage (discovery uses the Grafana token, API calls use the OnCall token), OnCall-token-falls-back-to-Grafana-token, and lazy resolution triggered by `NewRequest`.
- `go test ./...` (the new tests pass; note a few pre-existing integration-style tests fail on `main` independently of this change).

## Key decisions

- **Additive only, to preserve compatibility with older provider versions.** `New` and `NewWithGrafanaURL` are unchanged and still set the base URL eagerly. The new struct fields are unexported and inert for those callers. The only change to a shared method (`NewRequest`) is gated on `baseURL == nil`, which is only ever true for the autodiscovery constructor — so an older provider built against this client behaves identically (no extra request, no new error path).
- **Lazy on first request.** Resolution is deferred so constructing a client never performs I/O, and callers that never make a request never trigger a lookup.
- **OnCall token falls back to the Grafana auth token** when empty, so the single-service-account-token setup works out of the box.

## Notes to reviewers

- The plugin-settings lookup is a Grafana API call and sends `grafanaAuthToken` as a bearer token; OnCall API calls send their token verbatim (the OnCall API's existing scheme). The intended `grafanaAuthToken` is a Grafana service account token.
- This is the dependency half of a two-repo change; the Grafana Terraform provider PR consumes `NewWithGrafanaAutodiscovery` and will bump its dependency once this is released.